### PR TITLE
Add Chain Connect to the list

### DIFF
--- a/docs/node-providers/ChainConnect.md
+++ b/docs/node-providers/ChainConnect.md
@@ -1,0 +1,7 @@
+---
+sidebar_position: 6
+---
+
+# [Chain Connect](https://www.alchemy.com/chain-connect)
+
+Maintained by Alchemy and Developer DAO, Chain Connect is a resource for the web3 community to explore RPC endpoints from various providers and connect to a range of blockchain and network nodes all aggregated in one place.

--- a/docs/node-providers/node-providers.md
+++ b/docs/node-providers/node-providers.md
@@ -10,3 +10,4 @@ sidebar_position: 1
 - [Chainstack](https://www.chainstack.com/) From startups to large enterprises, thousands of businesses of all sizes use Chainstack’s software and APIs to build, run, and scale blockchain applications.
 - [Infura](https://infura.io/) Suite of high availability APIs and Developer Tools that can provide quick, reliable access to the Ethereum and IPFS networks so you can focus on building and scaling next-generation software.
 - [Quicknode](https://www.quicknode.com/) Hosted Blockchain Infrastructure as a Service.
+- [Chain Connect](https://www.alchemy.com/chain-connect) Maintained by Alchemy and Developer DAO, Chain Connect is a resource for the web3 community to explore RPC endpoints from various providers and connect to a range of blockchain and network nodes all aggregated in one place.


### PR DESCRIPTION
Chain Connect is an aggregator for all public RPC endpoints for each chain. It is a beneficial tool for developers to explore and select the right RPC endpoint.

P.S. - I work with Alchemy, and Alchemy and DeveloperDAO maintain this.