### PR TITLE
Fix/padding announcement bar

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -165,7 +165,8 @@ div[class^="announcementBar_"] {
     rgba(145, 227, 226, 1) 99%
   );
   font-weight: bold;
-  font-size: 1.34rem;
+  font-size: 1.54rem;
+  padding: 1.45em;
 }
 
 .red > a {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -165,7 +165,8 @@ div[class^="announcementBar_"] {
     rgba(145, 227, 226, 1) 99%
   );
   font-weight: bold;
-  font-size: 1.34rem;
+  font-size: 1.45rem;
+  padding:1.45em;
 }
 
 .red > a {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -165,8 +165,7 @@ div[class^="announcementBar_"] {
     rgba(145, 227, 226, 1) 99%
   );
   font-weight: bold;
-  font-size: 1.54rem;
-  padding: 1.45em;
+  font-size: 1.34rem;
 }
 
 .red > a {


### PR DESCRIPTION
What this PR does?

The announcement did not have enough padding at small screen sizes.
Additionally, increased the font size of the announcement to make it visually bigger with respect to the padding.
Fixes: #465 

Before:
![freeWeb_before](https://github.com/FrancescoXX/free-Web3-resources/assets/87471374/35fa8fcf-0a49-4c89-a049-00b348f7c8f8)

After:
![freeWeb_after](https://github.com/FrancescoXX/free-Web3-resources/assets/87471374/b359ab66-2b2b-4de8-9aa4-b0088f923a78)


