### PR TITLE
Fixed the height of the boxes present on the homepage of the website

### DIFF
--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -43,7 +43,8 @@
 }
 
 .listContainer{
-  min-height: 17rem;
+  min-height: 8.8rem;
+  max-height: 295px;
 }
 @media screen and (max-width: 768px) {
   .listContainer{


### PR DESCRIPTION
This pr fixed the height of the boxes on the homepage.
fixes #459
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Style**: Adjusted CSS styles for better mobile responsiveness
- Reduced the `min-height` property of the `.listContainer` class from `17rem` to `8.8rem` to optimize space utilization on smaller screens.
- Introduced a `max-height` property with a value of `295px` to the `.listContainer` class, ensuring consistent display across various screen sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->