### PR TITLE
Fix card component height on home page

### DIFF
--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -71,6 +71,7 @@
 .homecard{
   background-color: #1c1f26;
   width: 320px;
+  max-height: 300px;
   padding: 8px;
   position: relative;
   display: block;


### PR DESCRIPTION
### Description

This pull request addresses issue #459

### Changes Made

- Added the `max-height` property to the home card component CSS.
- Set the `max-height` to 300px.

### Screenshot

![image](https://github.com/FrancescoXX/free-Web3-resources/assets/102456428/ee961400-916d-4dc3-b89e-6f631165122f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Style: Adjusted the visual appearance of the home card element on the homepage. The `max-height` property has been added to limit its maximum height to 300 pixels, ensuring a more consistent and streamlined user interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->