### PR TITLE
changed content bar links to white

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -488,7 +488,7 @@ html[data-theme="light"]
 .menu__link,
 .table-of-contents__link,
 .menu__caret {
-  color:  #434242 !important;
+  color:  #ffffff !important;
 }
 html[data-theme="dark"]  
 .menu__link,


### PR DESCRIPTION
I have changed the content bar text links to white, as it was mismatching.

Before, it looked something like this:

![image](https://github.com/FrancescoXX/free-Web3-resources/assets/146617963/1cec9a1b-219a-44d9-90de-c5ccdfc85c28)

And after my changes, now it looks like this:

![image](https://github.com/FrancescoXX/free-Web3-resources/assets/146617963/ee353fcd-4269-4103-a484-e352d8721f7b)

Thanks and have a nice day

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Style: Updated color scheme for better readability in light theme. The text color for elements with classes `.menu__link`, `.table-of-contents__link`, and `.menu__caret` has been changed from `#434242` to `#ffffff`. This change enhances contrast and improves user experience when the HTML data theme is set to "light".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->