### PR TITLE
Fix Overlapping Issue by Adding Margin to Sidebar Menu

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -520,6 +520,7 @@ html[data-theme="light"] .menu__link,
 html[data-theme="light"] .table-of-contents__link,
 html[data-theme="light"] .menu__caret {
   color: #434242 !important;
+  margin-left: 25px;
 }
 
 html[data-theme="dark"] .menu__link,


### PR DESCRIPTION
I have resolved the issue where the sidebar menu items were overlapping with the icons within the sidebar.

![Screenshot 2023-10-24 193301](https://github.com/FrancescoXX/free-Web3-resources/assets/99758311/162856b5-5c6e-437a-b205-d20ce76acbfa)

![Screenshot 2023-10-24 194402](https://github.com/FrancescoXX/free-Web3-resources/assets/99758311/bcae4ca4-4be5-4155-8dce-791761159131)

@FrancescoXX , could you please review and merge this pull request ? 

It resolves the problem of sidebar items overlapping with icons by implementing the required margin.

Thank You.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- Style: Improved visual layout of the user interface in light theme mode. The update adds a left margin to menu links and table of contents links, enhancing readability and overall user experience. This change is particularly noticeable when the application is set to the "light" theme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->