### PR TITLE
fix: Added Space between icons in the side panel

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -527,6 +527,7 @@ html[data-theme="dark"] .menu__link,
 html[data-theme="dark"] .table-of-contents__link,
 html[data-theme="dark"] .menu__caret {
   color: white;
+  margin-left: 25px;
 }
 
 html[data-theme="light"] .navbar__title,


### PR DESCRIPTION
Added a  `margin-left: 25px ` in darkmode, so the space in maintained in both dark and light mode.

fixes #505 