### PR TITLE
Fix arrows in light mode

### DIFF
--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -65,6 +65,10 @@
   top: 0.5rem;
 }
 
+html[data-theme='light'] .listContainer li:before {
+  --ifm-menu-link-sublist-icon: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16px" height="16px" viewBox="0 0 24 24"><path fill="black" d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6-6 6z"></path></svg>');
+}
+
 .homecard {
   background-color: #1c1f26;
   width: 320px;


### PR DESCRIPTION
This pull request introduces a CSS customization to improve the appearance of list items in light theme mode. Specifically, it sets a custom SVG icon for list item bullets when the site is viewed in light theme.

Theme-specific styling:

* Added a CSS rule to `styles.module.css` to display a custom SVG icon as the bullet for list items in `.listContainer` when the `data-theme` attribute is set to `'light'`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated list item bullet styling to ensure proper visibility in both light and dark themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->