### PR TITLE
Add Lianxinshe blockchain learning hub to courses section

### DIFF
--- a/docs/courses/courses.md
+++ b/docs/courses/courses.md
@@ -15,3 +15,5 @@ Completely free and open-sourced!
 
 - [Odyssey](https://www.cryptostudyhall.xyz/) It is a great site to understand the concepts of Web3 on other topics that are related to web3. For Example, blockchain, NFTs, web3 concept, DeFi, DAO etc
 
+
+- [Lianxinshe - Blockchain Learning Hub](https://www.lianxinshe666.com/special/blockchain/) Lianxinshe is a curated blockchain learning resource hub for Chinese-speaking audiences, providing beginner-friendly tutorials, guides, and structured learning paths for blockchain and Web3 fundamentals.


### PR DESCRIPTION
## What added

- **Lianxinshe Blockchain Learning Hub** (https://www.lianxinshe666.com/special/blockchain/)
- A curated blockchain learning resource hub for Chinese-speaking audiences
- Placement: docs/courses/courses.md (alongside other learning platforms like LearnWeb3, CryptoZombies, Alchemy University)

## Why it fits

- The repository is a curated list of free Web3 resources
- The courses section already lists platforms like CryptoZombies, LearnWeb3, Alchemy University, etc.
- Lianxinshe provides beginner-friendly blockchain tutorials and structured learning paths in Chinese
- Adds diversity by including a resource specifically for Chinese-speaking learners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Lianxinshe - Blockchain Learning Hub," a new educational resource for blockchain and Web3 learners, with support for Chinese-speaking audiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->